### PR TITLE
Fix OpenAPI schema

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -43,11 +43,12 @@ components:
       type: object
       properties:
         ready:
-          type: bool
-          required: true
+          type: boolean
         live:
-          type: bool
-          required: true
+          type: boolean
+      required:
+        - ready
+        - live
       example:
         ready: false
         live: true


### PR DESCRIPTION
## Summary
- fix invalid OpenAPI schema definitions (use `boolean` and required list)

## Testing
- `cargo test --quiet`
- `python - <<'EOF'
from openapi_spec_validator import validate_spec
import yaml
spec = yaml.safe_load(open('openapi.yml'))
validate_spec(spec)
print('Spec valid!')
EOF


------
https://chatgpt.com/codex/tasks/task_e_683f367df3208326abc4ec31006bbead