### PR TITLE
Extract defaults to constants

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,13 @@
 use std::env;
 
+pub const DEFAULT_HOST: &str = "127.0.0.1";
+pub const DEFAULT_PORT: &str = "3000";
+
 pub const READYZ_ROUTE: &str = "/readyz";
 pub const LIVEZ_ROUTE: &str = "/livez";
 
 pub fn get_server_addr() -> String {
-    let host = env::var("HTTP_HOST").unwrap_or("127.0.0.1".into());
-    let port = env::var("HTTP_PORT").unwrap_or("3000".into());
+    let host = env::var("HTTP_HOST").unwrap_or_else(|_| DEFAULT_HOST.into());
+    let port = env::var("HTTP_PORT").unwrap_or_else(|_| DEFAULT_PORT.into());
     format!("{host}:{port}")
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -7,8 +7,10 @@ use axum::response::Html;
 
 use crate::models::App;
 
+pub const INDEX_HTML: &str = "<p>Hello, World!</p>";
+
 pub async fn index() -> Html<&'static str> {
-    Html("<p>Hello, World!</p>")
+    Html(INDEX_HTML)
 }
 
 pub async fn update(app: State<Arc<RwLock<App>>>, Json(new): Json<App>) -> StatusCode {

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -3,8 +3,11 @@ use std::env;
 use tracing::metadata::LevelFilter;
 use tracing_subscriber::{EnvFilter, fmt};
 
+pub const DEFAULT_LOG_ANSI: &str = "1";
+pub const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::INFO;
+
 pub fn init_logger() {
-    let use_ansi = env::var("HTTP_LOG_ANSI").unwrap_or("1".to_owned());
+    let use_ansi = env::var("HTTP_LOG_ANSI").unwrap_or_else(|_| DEFAULT_LOG_ANSI.to_owned());
     let use_ansi = !(use_ansi.is_empty() || use_ansi == "0"); // i.e. HTTP_LOG_ANSI=0 turns it off
 
     let format = fmt::format()
@@ -15,7 +18,7 @@ pub fn init_logger() {
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::builder()
-                .with_default_directive(LevelFilter::INFO.into())
+                .with_default_directive(DEFAULT_LOG_LEVEL.into())
                 .from_env_lossy(),
         )
         .event_format(format)

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,5 +1,8 @@
 use serde::{Deserialize, Serialize};
 
+pub const DEFAULT_READY: bool = true;
+pub const DEFAULT_LIVE: bool = true;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct App {
     pub ready: bool,
@@ -9,8 +12,8 @@ pub struct App {
 impl Default for App {
     fn default() -> Self {
         Self {
-            ready: true,
-            live: true,
+            ready: DEFAULT_READY,
+            live: DEFAULT_LIVE,
         }
     }
 }


### PR DESCRIPTION
## Summary
- define constants for defaults like host, port, log settings, and index HTML
- use constants in config, logging, handler and model defaults

## Testing
- `cargo build`
- `cargo test`
- ❌ `cargo +nightly fmt` *(fails: unsuccessful tunnel)*
- ❌ `rustup component add rustfmt` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_68401c443d00832687b33259bbeebe0c